### PR TITLE
Feature für verschiedene parallele Abstimmungen

### DIFF
--- a/html/join.hbs
+++ b/html/join.hbs
@@ -42,7 +42,7 @@
   <body class="text-center">
     <div class="container">
       <div class="row">
-        <form class="form-signin" id="accForm" action="/stimmung" method="POST">
+        <form class="form-signin" id="accForm" action="{{action}}" method="POST">
           <label for="name" class="sr-only">Anzeigename</label>
           <input
             type="text"

--- a/html/stimmung.hbs
+++ b/html/stimmung.hbs
@@ -8,6 +8,10 @@
   <meta name="generator" content="Jekyll v3.8.5" />
   <title>{{html_title}}</title>
 
+  <script type="text/javascript">
+    const roomId = '{{room}}';
+  </script>
+
   <script src="/js/jquery-3.4.1.min.js"></script>
   <script src="/js/cards.js"></script>
   <link href="/css/cards.css" rel="stylesheet" />

--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ function checkAuth(req, res, next) {
   }
 
   if (!req.session.name) {
+    req.session.redirectUri = req.originalUrl;
     res.redirect("/");
   } else {
     next();
@@ -71,6 +72,7 @@ if (!oauthEnabled) {
       html_author: process.env.HTML_AUTHOR ? process.env.HTML_AUTHOR : "",
       name_pattern: process.env.NAME_PATTERN ? process.env.NAME_PATTERN : ".*",
       name: req.session.name,
+      action: req.session.redirectUri || '/stimmung',
     });
   });
 } else {
@@ -103,7 +105,7 @@ if (!oauthEnabled) {
         .join(" ")
         .trim();
 
-      return res.redirect("/stimmung");
+      return res.redirect(req.session.redirectUri || "/stimmung");
     } catch (exception) {
       // TODO: do actual error handling
       return res.redirect("/");

--- a/js/cards.js
+++ b/js/cards.js
@@ -11,7 +11,8 @@ $(document).ready(() => {
   let wsUrl =
     (location.protocol == "https:" ? "wss://" : "ws://") +
     location.hostname +
-    (location.port ? ":" + location.port : "");
+    (location.port ? ":" + location.port : "") +
+    '/' + roomId;
   var socket = new WebSocket(wsUrl, "stimmung"); // "ws://localhost:8080/"
   socket.onopen = function () {
     socket.send(


### PR DESCRIPTION
Erlaubt die Verwendung des Tools für verschiedene Abstimmungen parallel:
als zusätzlicher URL-Parameter kann eine Raum-ID angegeben werden: `/stimmung/<raumID>`

Angezeigt werden dann nur Teilnehmer und Stimmen im selben Raum. Ein neuer Raum kann einfach durch hinzufügen der frei gewählten ID "erstellt" werden.